### PR TITLE
fix: install all dependencies for gist scripts

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -16,7 +16,9 @@ jobs:
             - hyperctl-download: bash -xe scripts/hyperctl-download.sh
             - chmod: chmod +x ./hyperctl
             - test-hyperctl: ./hyperctl info -h
-            - setup-ci: sd-step exec core/git "git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci"
+            # Dependencies for the gist scripts; should make the scripts share steps in the future
+            - install-dependencies: yum install -y git wget openssh-clients
+            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - tag: ./ci/git-tag.sh
             - release: ./ci/git-release.sh
         environment:


### PR DESCRIPTION
Ah, it turned out the image does not have `openssh`, `git`, `wget` and all of them are needed in the gist scripts. Should really make the script hab share steps in the future.