### PR TITLE
fix: Increase the resources assigned to the vm

### DIFF
--- a/scripts/hyper-runner.sh
+++ b/scripts/hyper-runner.sh
@@ -86,5 +86,5 @@ sed -e "s|BUILD_CONTAINER|${BUILD_CONTAINER}|g;
 
 log 'Running hyperctl...'
 HYPERCTL=/usr/bin/hyperctl
-res=`$HYPERCTL run --rm -a -p $HYPER_POD_SPEC`
+res=`$HYPERCTL run --cpu=2 --memory=512 --rm -a -p $HYPER_POD_SPEC`
 log "Build finished with exit code $? : $res"


### PR DESCRIPTION
By default, the resources assigned to the vm is:
`--cpu=1 --memory=128`
https://docs.hypercontainer.io/reference/run.html

The vm build is very low with the settings. Increase resources to see if it gets better.