### PR TITLE
fix(729): use toolbox repo instead of gist

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -16,7 +16,7 @@ jobs:
             - hyperctl-download: bash -xe scripts/hyperctl-download.sh
             - chmod: chmod +x ./hyperctl
             - test-hyperctl: ./hyperctl info -h
-            # Dependencies for the gist scripts; should make the scripts share steps in the future
+            # Dependencies for the scripts; should make the scripts share steps in the future
             - install-dependencies: yum install -y git wget openssh-clients bzip2
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - tag: ./ci/git-tag.sh

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -18,7 +18,7 @@ jobs:
             - test-hyperctl: ./hyperctl info -h
             # Dependencies for the gist scripts; should make the scripts share steps in the future
             - install-dependencies: yum install -y git wget openssh-clients bzip2
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - tag: ./ci/git-tag.sh
             - release: ./ci/git-release.sh
         environment:


### PR DESCRIPTION
I found https://cd.screwdriver.cd/pipelines/254/builds/11020 was failed.
It looks same issue with https://github.com/screwdriver-cd/screwdriver/issues/729 .
Use toolbox repo instead of personal gist.