### PR TITLE
fix: Escape quotes for int vars

### DIFF
--- a/scripts/hyper-runner.sh
+++ b/scripts/hyper-runner.sh
@@ -96,8 +96,8 @@ sed -e "s|BUILD_CONTAINER|${BUILD_CONTAINER}|g;
         s|STORE_URI|${STORE_URI}|g;
         s|BUILD_TOKEN|${BUILD_TOKEN}|g;
         s|ID_WITH_PREFIX|${ID_WITH_PREFIX}|g;
-        s|CPU|${CPU}|g;
-        s|MEMORY|${MEMORY}|g;" $HYPER_TEMPLATE > $HYPER_POD_SPEC;
+        s|\"CPU\"|${CPU}|g;
+        s|\"MEMORY\"|${MEMORY}|g;" $HYPER_TEMPLATE > $HYPER_POD_SPEC;
 
 log 'Running hyperctl...'
 res=`$HYPERCTL run --rm -a -p $HYPER_POD_SPEC`


### PR DESCRIPTION
Hyperd only takes CPU and memory as ints, but the environment variable was getting set as a string.
This PR fixes that issue.

Related to https://github.com/screwdriver-cd/hyperctl-image/pull/9