### PR TITLE
fix: Remove leading and trailing quotes from CPU and MEMORY vars

### DIFF
--- a/scripts/hyper-runner.sh
+++ b/scripts/hyper-runner.sh
@@ -82,6 +82,10 @@ if [[ -z "$MEMORY" ]]; then
   MEMORY=2048;
 fi
 
+# Remove leading and trailing quotes from CPU and MEMORY
+CPU=`sed -e 's/^"//' -e 's/"$//' <<< "$CPU"`
+MEMORY=`sed -e 's/^"//' -e 's/"$//' <<< "$MEMORY"`
+
 # Copy install_docker script to the share mount sdlauncher on the host
 cp /sd/install_docker.sh /opt/sd
 


### PR DESCRIPTION
Was getting an error from worker logs:
```
error: err in start job:  Error: Failed to create pod: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod in version \"v1\" cannot be handled as a Pod: [pos 997]: json: expect char '\"' but got char '6'","reason":"BadRequest","code":400}
```

This PR aims to fix those issues.

Related to: https://github.com/screwdriver-cd/executor-k8s-vm/pull/14
Original issues: https://github.com/screwdriver-cd/screwdriver/issues/758, https://github.com/screwdriver-cd/screwdriver/issues/759