### PR TITLE
fix: remove docker install script

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -14,7 +14,7 @@
         "--",
         "/bin/sh",
         "-c",
-        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && . /opt/sd/install_docker.sh && /opt/sd/launch --api-uri API_URI --emitter /opt/sd/emitter BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
+        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --emitter /opt/sd/emitter BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
       ],
       "volumes": [
         {


### PR DESCRIPTION
remove docker install script since docker is not required by every single build.
user can install it in their builds if they need it

note: make it consistent with internal one