### PR TITLE
feat: set store uri when launch

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -14,7 +14,7 @@
         "--",
         "/bin/sh",
         "-c",
-        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --emitter /opt/sd/emitter BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
+        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /opt/sd/emitter BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
       ],
       "volumes": [
         {


### PR DESCRIPTION
## Context
Add store url argument when call launch command.

We need to use store url when use sd-cmd. 
By this [PR](https://github.com/screwdriver-cd/launcher/pull/138), we can set store api. 

## Objective
Call launch command with `--store-uri` argument.

## References
[launcher PR for store url argument](https://github.com/screwdriver-cd/launcher/pull/138)
  