### PR TITLE
fix: switch to use entryPoint instead of command

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -9,7 +9,7 @@
     {
       "name": "ID_WITH_PREFIX",
       "image": "BUILD_CONTAINER",
-      "command": [
+      "entryPoint": [
         "/opt/sd/tini",
         "--",
         "/bin/sh",


### PR DESCRIPTION
switch to use entryPoint instead of command to override user image's default entrypoint