### PR TITLE
fix: pass build timeout to launcher and not log service

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -14,7 +14,7 @@
         "--",
         "/bin/sh",
         "-c",
-        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /opt/sd/emitter BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID --build-timeout SD_BUILD_TIMEOUT & wait $(jobs -p)"
+        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /opt/sd/emitter --build-timeout SD_BUILD_TIMEOUT BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
       ],
       "volumes": [
         {


### PR DESCRIPTION
## Context

The arguments for `--build-timeout` were passed to the `log-service` and not the `launcher`.

## Objective

Pass the build timeout value to the launcher

## Reference

* PR introducing this bug 
   * https://github.com/screwdriver-cd/hyperctl-image/pull/18