### PR TITLE
fix(877): cp hab cache to /hab [3]

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -14,7 +14,7 @@
         "--",
         "/bin/sh",
         "-c",
-        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /sd && /opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /opt/sd/emitter --build-timeout SD_BUILD_TIMEOUT BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
+        "while ! [ -f /opt/sd/launch ]; do sleep 1; done; mkdir -p /hab && cp -a /opt/sd/hab/* /hab && mkdir -p /sd && /opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /opt/sd/emitter --build-timeout SD_BUILD_TIMEOUT BUILD_ID & /opt/sd/logservice --emitter /opt/sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p)"
       ],
       "volumes": [
         {


### PR DESCRIPTION
cp hab cache to /hab

Blocked by: https://github.com/screwdriver-cd/queue-worker/pull/88
Related to https://github.com/screwdriver-cd/screwdriver/issues/877