### PR TITLE
feat(1114): Pass in API URI to log-service. BREAKING CHANGE: switching var names

### DIFF
--- a/scripts/hyper-pod-template.json
+++ b/scripts/hyper-pod-template.json
@@ -14,7 +14,7 @@
         "--",
         "/bin/sh",
         "-c",
-        "while ! [ -f /opt/sd/setup.sh ]; do sleep 1; done; /opt/sd/setup.sh && (/opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /sd/emitter --build-timeout SD_BUILD_TIMEOUT BUILD_ID & /opt/sd/logservice --emitter /sd/emitter --api-uri STORE_URI --build BUILD_ID & wait $(jobs -p))"
+        "while ! [ -f /opt/sd/setup.sh ]; do sleep 1; done; /opt/sd/setup.sh && (/opt/sd/launch --api-uri API_URI --store-uri STORE_URI --emitter /sd/emitter --build-timeout SD_BUILD_TIMEOUT BUILD_ID & /opt/sd/logservice --emitter /sd/emitter --api-uri API_URI --store-uri STORE_URI --build BUILD_ID & wait $(jobs -p))"
       ],
       "volumes": [
         {


### PR DESCRIPTION
Need to pass in API and Store urls.

Previously, we were passing in store uri like this:
```
--api-uri STORE_URI
```
Fixing the env var names in this PR. Also makes it more consistent with launcher.
```
--api-uri API_URI --store-uri STORE_URI
```

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114

*Note: I already pushed git tag v1.0.0.*