### PR TITLE
fix(1378): [small] cleanup workspaces when catch signals

### DIFF
--- a/scripts/hyper-runner.sh
+++ b/scripts/hyper-runner.sh
@@ -1,16 +1,25 @@
 #!/bin/bash -e
 
-# Trap the EXIT SIGNAL and update build status to failure
-trap cleanUp EXIT
+# Trap these SIGNALs to cleanup workspace and update build status to failure
+trap cleanUp HUP INT QUIT TERM EXIT
 
 function cleanUp {
     if [ "$?" = "0" ]
     then
+        cleanupWorkspaces
         echo "exit with exit code 0"
         exit 0
     fi
     echo "exit with non-zero code"
+
+    cleanupWorkspaces
     updateBuildStatus
+}
+
+function cleanupWorkspaces {
+    echo "cleanup used workspaces..."
+    rm -rf /var/sd-workspaces/${ID_WITH_PREFIX}
+    $HYPERCTL rm builder-${ID_WITH_PREFIX}
 }
 
 function updateBuildStatus {


### PR DESCRIPTION
## Context
The executor should remove the build and its directories before stopping the build. Currently [preStop hook](https://github.com/screwdriver-cd/executor-k8s-vm/blob/0be448d5889d2d701123f9ab2972293024a8670f/config/pod.yaml.tim#L60-L64) handles that but it won't be happened since https://github.com/screwdriver-cd/executor-k8s-vm/pull/46 . And abandoned VMs and launcher binaries fill up our Kubernetes workers' cpu, memory and disk.

## Objective
- Add `cleanupWorkspaces` function which removes workspaces and a VM same as https://github.com/screwdriver-cd/executor-k8s-vm/blob/0be448d5889d2d701123f9ab2972293024a8670f/config/pod.yaml.tim#L60-L64
- Add targets of trap, `HUP`, `INT`, `QUIT`, `TERM`

## Related
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/1378
- https://github.com/screwdriver-cd/executor-k8s-vm/pull/47